### PR TITLE
fix(ci): upgrade Cerberus to v2 with OpenRouter API key

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: "${{ matrix.reviewer }}"
     runs-on: ubuntu-latest
     strategy:
@@ -29,11 +30,12 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: misty-step/cerberus@v1
+      - uses: misty-step/cerberus@v2
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kimi-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+          api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          timeout: '600'
 
   verdict:
     name: "Council Verdict"
@@ -41,6 +43,6 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: misty-step/cerberus/verdict@v1
+      - uses: misty-step/cerberus/verdict@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
Cerberus reviews failing on all PRs — `Missing API key for Cerberus review`

The cadence repo was using cerberus@v1 with `kimi-api-key`, but the current Cerberus version expects `api-key` (with OPENROUTER_API_KEY secret).

## Fix
- Upgrade cerberus@v1 → cerberus@v2
- Switch from `kimi-api-key` to `api-key: ${{ secrets.OPENROUTER_API_KEY }}`
- Add fork PR protection guard  
- Add 600s timeout
- Aligned with bitterblossom's working config

## Impact
Once merged, PRs #4 and #5 can be re-triggered and will get proper Cerberus reviews.