### PR TITLE
fix: use normal timer window level

### DIFF
--- a/Sources/CadenceKit/WindowManager.swift
+++ b/Sources/CadenceKit/WindowManager.swift
@@ -41,11 +41,11 @@ public final class WindowManager<Content: View>: NSObject, NSWindowDelegate {
         window.isMovableByWindowBackground = true
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
-        window.standardWindowButton(.closeButton)?.isHidden = true
+        window.standardWindowButton(.closeButton)?.isHidden = false
+        window.standardWindowButton(.miniaturizeButton)?.isHidden = false
         window.standardWindowButton(.zoomButton)?.isHidden = true
-        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
 
-        window.level = .floating
+        window.level = .normal
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
         window.delegate = self


### PR DESCRIPTION
## Summary
- stop forcing the timer window above other apps
- restore close and minimize window controls
- keep zoom hidden because the timer window is fixed-size by design

## Test coverage
- `swift build`
- `swift test`

## Manual QA
- Relaunched the local `Cadence.app` bundle from this branch for window behavior testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Window close and miniaturize buttons are now visible; zoom button remains hidden.
  * Adjusted window stacking behavior from floating to normal level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/misty-step/cadence/pull/30)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->