### PR TITLE
[codex] show Cadence in app switcher

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,9 @@
 disabled_rules:
   - todo
 
+excluded:
+  - .build
+
 opt_in_rules:
   - force_unwrapping
   - explicit_init

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ See [docs/CODEBASE_MAP.md](docs/CODEBASE_MAP.md) for full architecture.
 - **SPM executable, not Xcode project.** Build with `swift build`, not Xcode. App bundle constructed manually by `scripts/bundle.sh` with embedded Info.plist via linker flags.
 - **`@Observable`, not `ObservableObject`.** Uses Swift Observation framework. Views use `@Bindable`, not `@ObservedObject`.
 - **Timer durations are intentionally hardcoded.** 25/5/15 minutes. Not configurable by design (see spec.md).
-- **LSUIElement = true.** No dock icon. Menu bar + floating window only.
+- **Regular macOS app.** Cadence appears in Dock and Command-Tab, with a menu bar item for quick window access.
 - **Ad-hoc code signing.** No developer certificate. `codesign --sign -`.
 - **`NotificationManager()` created per tick.** `startBackgroundTimer` creates a new instance each second instead of using the shared one. Functional but wasteful.
 - **Status bar polls at 0.5s** instead of using `withObservationTracking`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A native macOS Pomodoro timer. Stays on your desktop, out of the way.
 - 5 minute short breaks (15 min after 4 sessions)
 - Space to start/pause
 - Menu bar icon to show/hide
+- Dock and Command-Tab access
 
 No settings. No accounts. Just a timer.
 

--- a/Sources/Cadence/CadenceApp.swift
+++ b/Sources/Cadence/CadenceApp.swift
@@ -26,7 +26,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var lastIsRunning: Bool = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        NSApp.setActivationPolicy(.accessory)
+        NSApp.setActivationPolicy(.regular)
         registerFonts()
         notificationManager.requestAuthorizationIfNeeded()
 

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -82,7 +82,7 @@ cadence/
 
 **Purpose**: App entry point + menu bar icon rendering.
 
-**AppDelegate**: Sets `.accessory` activation policy (no dock icon). Creates `WindowManager`, `NotificationManager`, `TimerState`. Sets up `NSStatusItem` with left-click (toggle window) and right-click (context menu: Show Timer, Quit).
+**AppDelegate**: Sets `.regular` activation policy so Cadence appears in Dock and Command-Tab. Creates `WindowManager`, `NotificationManager`, `TimerState`. Sets up `NSStatusItem` with left-click (toggle window) and right-click (context menu: Show Timer, Quit).
 
 **MenuBarIconImage**: Renders 6 distinct NSImage states based on (phase, isRunning) — filled circle, stroked circle, half-filled, dashed, etc. Uses `NSBezierPath` drawing, marked as template image.
 
@@ -129,7 +129,7 @@ cadence/
 
 3. **SPM executable, not Xcode project**: Build via `swift build` or `scripts/bundle.sh`, not Xcode. The `.app` bundle is constructed manually with embedded `Info.plist` via linker flags (`-sectcreate __TEXT __info_plist`).
 
-4. **LSUIElement = true**: App has no dock icon. Only visible via menu bar and floating window.
+4. **Regular app identity**: App appears in Dock and Command-Tab. The menu bar item remains a quick way to show or hide the timer window.
 
 5. **Ad-hoc code signing**: No developer certificate. Uses `codesign --sign -` which limits distribution (no notarization, no App Store).
 

--- a/docs/adr/004-regular-app-identity.md
+++ b/docs/adr/004-regular-app-identity.md
@@ -1,0 +1,32 @@
+# 004. Regular App Identity over Agent App
+
+Date: 2026-05-14
+
+## Status
+
+Accepted
+
+## Context
+
+Cadence previously ran as an agent app by setting `LSUIElement=true` in the
+manual app bundle and `.accessory` as the runtime activation policy. That kept
+Cadence out of the Dock and Command-Tab app switcher.
+
+The timer still has a menu bar control, but users also expect standard macOS
+navigation to work for a visible app window.
+
+## Decision
+
+Run Cadence as a regular macOS app. The app appears in the Dock and Command-Tab,
+and the menu bar item remains available for quick show/hide control.
+
+Because Cadence uses Swift Package Manager rather than an Xcode project, the
+bundle scripts generate and copy `Cadence.icns` directly into the app bundle.
+
+## Consequences
+
+- **Good**: Users can return to Cadence through standard macOS app switching.
+- **Good**: The app has a real Dock and Command-Tab icon.
+- **Good**: The menu bar control remains available.
+- **Bad**: Cadence now takes a Dock slot while running.
+- **Bad**: Manual bundle assembly has one more packaging responsibility.

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -9,6 +9,7 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 BUILD_DIR="$PROJECT_DIR/.build/release"
 APP_NAME="Cadence"
 APP_BUNDLE="$PROJECT_DIR/$APP_NAME.app"
+ICON_FILE="$APP_BUNDLE/Contents/Resources/Cadence.icns"
 
 # Create Info.plist in a temp location
 TEMP_PLIST="/tmp/Cadence_Info.plist"
@@ -29,10 +30,10 @@ cat > "$TEMP_PLIST" << 'EOF'
     <string>1.0</string>
     <key>CFBundleExecutable</key>
     <string>Cadence</string>
+    <key>CFBundleIconFile</key>
+    <string>Cadence</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
-    <key>LSUIElement</key>
-    <true/>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>
@@ -64,6 +65,8 @@ if [ -d "$RESOURCES_BUNDLE" ]; then
         cp "$f" "$APP_BUNDLE/Contents/Resources/"
     done
 fi
+
+python3 "$SCRIPT_DIR/generate-icon.py" "$ICON_FILE"
 
 # Copy Info.plist to bundle as well (for app discovery)
 cp "$TEMP_PLIST" "$APP_BUNDLE/Contents/Info.plist"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -25,6 +25,8 @@ if [ -d "$RESOURCES_BUNDLE" ]; then
     done
 fi
 
+python3 "$(dirname "$0")/generate-icon.py" "$DEBUG_APP/Contents/Resources/Cadence.icns"
+
 # Create Info.plist
 cat > "$DEBUG_APP/Contents/Info.plist" << 'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
@@ -37,8 +39,8 @@ cat > "$DEBUG_APP/Contents/Info.plist" << 'EOF'
     <string>dev.mistystep.cadence.debug</string>
     <key>CFBundleName</key>
     <string>Cadence-Dev</string>
-    <key>LSUIElement</key>
-    <true/>
+    <key>CFBundleIconFile</key>
+    <string>Cadence</string>
 </dict>
 </plist>
 EOF

--- a/scripts/generate-icon.py
+++ b/scripts/generate-icon.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Generate Cadence.icns without an Xcode asset catalog."""
+
+from __future__ import annotations
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import zlib
+from pathlib import Path
+
+
+def chunk(kind: bytes, data: bytes) -> bytes:
+    payload = kind + data
+    return struct.pack(">I", len(data)) + payload + struct.pack(">I", zlib.crc32(payload) & 0xFFFFFFFF)
+
+
+def write_png(path: Path, size: int) -> None:
+    rows = []
+    radius = size * 0.22
+    border = max(1, round(size * 0.035))
+    ring_width = max(2, round(size * 0.085))
+    cx = cy = (size - 1) / 2
+    outer_r = size * 0.34
+    inner_r = outer_r - ring_width
+
+    for y in range(size):
+        row = bytearray()
+        for x in range(size):
+            edge_distance = min(x, y, size - 1 - x, size - 1 - y)
+            corner_x = min(x, size - 1 - x)
+            corner_y = min(y, size - 1 - y)
+            corner_distance = ((corner_x - radius) ** 2 + (corner_y - radius) ** 2) ** 0.5
+
+            if corner_x < radius and corner_y < radius and corner_distance > radius:
+                row.extend((0, 0, 0, 0))
+                continue
+
+            if edge_distance < border:
+                row.extend((255, 255, 255, 255))
+                continue
+
+            d = ((x - cx) ** 2 + (y - cy) ** 2) ** 0.5
+            if inner_r <= d <= outer_r:
+                row.extend((255, 255, 255, 255))
+            elif abs(x - cx) <= ring_width * 0.38 and cy - outer_r * 0.5 <= y <= cy + outer_r * 0.55:
+                row.extend((255, 255, 255, 255))
+            else:
+                row.extend((34, 40, 49, 255))
+        rows.append(b"\x00" + bytes(row))
+
+    raw = b"".join(rows)
+    png = (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", size, size, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(raw, 9))
+        + chunk(b"IEND", b"")
+    )
+    path.write_bytes(png)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: generate-icon.py OUTPUT.icns", file=sys.stderr)
+        return 2
+
+    output = Path(sys.argv[1]).resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        iconset = Path(tmp) / "Cadence.iconset"
+        iconset.mkdir()
+        for points in (16, 32, 128, 256, 512):
+            write_png(iconset / f"icon_{points}x{points}.png", points)
+            write_png(iconset / f"icon_{points}x{points}@2x.png", points * 2)
+
+        subprocess.run(["iconutil", "-c", "icns", str(iconset), "-o", str(output)], check=True)
+
+    os.chmod(output, 0o644)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spec.md
+++ b/spec.md
@@ -40,7 +40,7 @@ These values are not configurable. They're correct.
 - Native macOS APIs (no Electron)
 - Lightweight (~5MB)
 - Fast launch, minimal memory footprint
-- Runs in menu bar, not dock
+- Appears in Dock and Command-Tab, with a menu bar control for quick access
 
 ## The Loop
 
@@ -61,7 +61,7 @@ Session 4: Focus (25) → Long Break (15)
 
 ## UI Concept
 
-**Menu bar icon:** Simple circle that fills as the timer progresses. Red during focus, green during break.
+**Menu bar icon:** Simple circle that reflects the current timer phase and running state.
 
 **Click to expand:** Shows current phase, time remaining, and a single Start/Pause button.
 


### PR DESCRIPTION
## Summary

Cadence now runs as a regular macOS app instead of an agent/accessory app, so it appears in the Dock and Command-Tab app switcher while keeping the menu bar control for quick window access.

## What changed

- Switch runtime activation from `.accessory` to `.regular`.
- Remove `LSUIElement` from dev and release bundle plists.
- Add `CFBundleIconFile` to the generated app plists.
- Generate `Cadence.icns` during bundle creation without introducing an Xcode project or third-party dependency.
- Document the product decision in ADR 004 and update user/developer docs.
- Exclude SwiftPM `.build` output from SwiftLint so generated files do not fail lint after local builds.

## Why

The previous bundle metadata and runtime activation policy intentionally hid Cadence from the Dock and Command-Tab. That made the app hard to return to using standard macOS navigation even though it has a visible app window.

## Validation

- `swift build`
- `swift test` - 49 tests passed
- `swiftlint lint --quiet` - exits 0 with existing warnings
- `bash -n scripts/bundle.sh scripts/dev.sh`
- `python3 -m py_compile scripts/generate-icon.py`
- `./scripts/bundle.sh`
- `plutil -lint Cadence.app/Contents/Info.plist`
- Verified `CFBundleIconFile=Cadence`, `CFBundlePackageType=APPL`, and no `LSUIElement` in the generated bundle
- `codesign --verify --deep --strict --verbose=2 Cadence.app`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App now appears in Dock and Command-Tab, providing standard macOS app integration.
  * Menu bar item remains available for quick window access.
  * Menu bar icon now reflects the current timer phase and running state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/misty-step/cadence/pull/31)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->